### PR TITLE
Bugfix/10 fixing url opening on normal mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "webpack-dev-server --config ./webpack.config.js --mode development",
     "dev": "webpack --watch --progress --colors --config webpack.config.js --mode=development",
-    "test": "webpack --progress --colors --config webpack.config.js --mode=production"
+    "test": "webpack --progress --colors --config webpack.config.js --mode=production",
+    "build": "webpack -p --mode production"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Fixes #10 

So I don't think there is a way to change the active window/tab and still stop a different tab from continuing the request. What I ended up doing was hooking into `chrome.webRequest.onCompleted` to go back a step in the tab that the request came from. This seems to be doing the trick.

I also cleaned up the methods to not use the `redirectURL` too much and just allow chrome to handle the page changes when the extension doesn't need to. This can also make these functions more flexible when trying to use it for Firefox as well (possibly).

I also added a `build` script for webpack.